### PR TITLE
Fixed error in size computation in ConnectedComponents.

### DIFF
--- a/src/org/graphstream/algorithm/ConnectedComponents.java
+++ b/src/org/graphstream/algorithm/ConnectedComponents.java
@@ -478,7 +478,6 @@ public class ConnectedComponents extends SinkAdapter implements
 						if (connectedComponentsMap.get(n2) != id) {
 							open.add(n2);
 							connectedComponentsMap.put(n2, id);
-							size++;
 							markNode(n2, id); /* useless */
 						}
 						// Also work with (but slower):


### PR DESCRIPTION
This pull request fixes an error in the computation of the connected components sizes. The error appeared as soon as a new connected component was created due to a edge deletion or cut attribute set.
It lead to erroneous results in size display, and selection of connected components above or below a certain size.

This shall be considered as bug fix and integrated to baseline as soon as possible.

Regards,

-Guillaume
