### PR TITLE
Fixed raw connected component count.

### DIFF
--- a/src/org/graphstream/algorithm/ConnectedComponents.java
+++ b/src/org/graphstream/algorithm/ConnectedComponents.java
@@ -589,13 +589,22 @@ public class ConnectedComponents extends SinkAdapter implements
 
 				if (!(connectedComponentsMap.get(edge.getNode0())
 						.equals(connectedComponentsMap.get(edge.getNode1())))) {
-					connectedComponents++;
 
 					// Two new connected components are created
 					// we need to get the size of each of them
-					connectedComponentsSize.put(id, newSize);
-					connectedComponentsSize.remove(oldId);
-					connectedComponentsSize.put(oldId, oldSize - newSize);
+					if (newSize > 0) {
+						connectedComponentsSize.put(id, newSize);
+						connectedComponents++;
+					}
+					
+					if (oldSize - newSize > 0) {
+						connectedComponentsSize.put(oldId, oldSize - newSize);
+						
+					}
+					else {
+						connectedComponentsSize.remove(oldId);
+						connectedComponents--;
+					}
 
 				} else {
 					removeIdentifier(oldId);
@@ -675,12 +684,22 @@ public class ConnectedComponents extends SinkAdapter implements
 
 			if (!connectedComponentsMap.get(edge.getNode0()).equals(
 					connectedComponentsMap.get(edge.getNode1()))) {
-				connectedComponents++;
-
+				
 				// Two new connected components are created
 				// we need to get the size of each of them
-				connectedComponentsSize.put(id, newSize);
-				connectedComponentsSize.put(oldId, oldSize - newSize);
+				if (newSize > 0) {
+					connectedComponentsSize.put(id, newSize);
+					connectedComponents++;
+				}
+				
+				if (oldSize - newSize > 0) {
+					connectedComponentsSize.put(oldId, oldSize - newSize);
+					
+				}
+				else {
+					connectedComponentsSize.remove(oldId);
+					connectedComponents--;
+				}
 
 			} else {
 				removeIdentifier(oldId);


### PR DESCRIPTION
In ConnectedComponents, the number of components is available either via
a counter (connectedComponents), or by using the size of the
connectedComponentSize map. The former allow easy access to the number of
components (raw count), the second to filter the result based on component
size restriction at a cost of a more complex operation.

The count update could, in some cases, create empty connected components. Those
were counted and lead to erroneous results where the raw count of connected
components was used. Empty connected components are now filtered out during the
raw and size-based count.
