### PR TITLE
Set ChartMeasure location to center of display

### DIFF
--- a/src/org/graphstream/algorithm/measure/ChartMeasure.java
+++ b/src/org/graphstream/algorithm/measure/ChartMeasure.java
@@ -253,6 +253,7 @@ public abstract class ChartMeasure {
 
 			JFrame frame = new JFrame(params.title);
 			frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+			frame.setLocationRelativeTo(null);
 			frame.add(panel);
 			frame.pack();
 			frame.setVisible(true);


### PR DESCRIPTION
- Have the outputted plot (chart - JFrame window) centered by default when it's displayed
