### PR TITLE
Remove excess checks for unmarked nodes in Topological Sort

### DIFF
--- a/src/org/graphstream/algorithm/TopologicalSort.java
+++ b/src/org/graphstream/algorithm/TopologicalSort.java
@@ -143,21 +143,12 @@ public class TopologicalSort implements Algorithm {
         }
 
         int[] marks = new int[graph.getNodeCount()];
-        Node n;
-
-        while ((n = getUnmarkedNode(marks)) != null) {
-            visitNode(n, marks);
-        }
-    }
-
-    private Node getUnmarkedNode(int[] marks) {
+        
         for (int i = 0; i < marks.length; i++) {
             if (marks[i] == MARK_UNMARKED) {
-                return graph.getNode(i);
+                visitNode(graph.getNode(i), marks);
             }
         }
-
-        return null;
     }
 
     private void visitNode(Node node, int[] marks) {


### PR DESCRIPTION
Having getUnmarkedNode as a separate function and repeatedly calling can lead to quadratic checks. Looping once over all nodes and visiting unmarked nodes guarantees that all nodes will be checked just once.