### PR TITLE
[2.x] Transition into Stream

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,8 +190,8 @@
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.7</source>
-					<target>1.7</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 				<version>3.3</version>
 			</plugin>

--- a/src-test/org/graphstream/algorithm/networksimplex/test/TestDynamicOneToAllShortestPath.java
+++ b/src-test/org/graphstream/algorithm/networksimplex/test/TestDynamicOneToAllShortestPath.java
@@ -133,7 +133,7 @@ public class TestDynamicOneToAllShortestPath {
 		for (int i = 3; i <= 100; i++) {
 			gen.nextEvents();
 			d.compute();
-			BreadthFirstIterator<Node> bfs = (BreadthFirstIterator<Node>) source
+			BreadthFirstIterator bfs = (BreadthFirstIterator) source
 					.getBreadthFirstIterator();
 			while (bfs.hasNext())
 				bfs.next();
@@ -145,7 +145,7 @@ public class TestDynamicOneToAllShortestPath {
 		for (int i = 100; i >= 3; i--) {
 			g.removeNode(i);
 			d.compute();
-			BreadthFirstIterator<Node> bfs = (BreadthFirstIterator<Node>) source
+			BreadthFirstIterator bfs = (BreadthFirstIterator) source
 					.getBreadthFirstIterator();
 			while (bfs.hasNext())
 				bfs.next();

--- a/src-test/org/graphstream/algorithm/networksimplex/test/TestNetworkSimplex.java
+++ b/src-test/org/graphstream/algorithm/networksimplex/test/TestNetworkSimplex.java
@@ -107,13 +107,12 @@ public class TestNetworkSimplex {
 		assertEquals(ns1.getSolutionCost(), ns2.getSolutionCost());
 		assertEquals(ns1.getSolutionInfeasibility(), ns2.getSolutionInfeasibility());
 		
-		for (Node n : g)
-			assertEquals(ns1.getInfeasibility(n), ns2.getInfeasibility(n));
+		g.nodes().forEach(n -> assertEquals(ns1.getInfeasibility(n), ns2.getInfeasibility(n)));
 
-		for (Edge e : g.getEachEdge()) {
+		g.edges().forEach(e -> {
 			assertEquals(ns1.getFlow(e, true), ns2.getFlow(e, true));
 			assertEquals(ns1.getFlow(e, false), ns2.getFlow(e, false));
-		}
+		});
 	}
 
 	public static void compareWithNew(NetworkSimplex ns) {

--- a/src-test/org/graphstream/algorithm/test/TestAPSP.java
+++ b/src-test/org/graphstream/algorithm/test/TestAPSP.java
@@ -31,17 +31,20 @@
  */
 package org.graphstream.algorithm.test;
 
-import java.io.*;
-import java.util.Iterator;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
-import org.graphstream.algorithm.*;
+import java.io.IOException;
+
+import org.graphstream.algorithm.APSP;
 import org.graphstream.algorithm.APSP.APSPInfo;
-import org.graphstream.graph.*;
+import org.graphstream.graph.Edge;
+import org.graphstream.graph.Graph;
+import org.graphstream.graph.Node;
+import org.graphstream.graph.Path;
 import org.graphstream.graph.implementations.SingleGraph;
-import org.graphstream.stream.*;
-
-import org.junit.*;
-import static org.junit.Assert.*;
+import org.graphstream.stream.GraphParseException;
+import org.junit.Test;
 
 /**
  * Test the APSP algorithm.

--- a/src-test/org/graphstream/algorithm/test/TestAPSP.java
+++ b/src-test/org/graphstream/algorithm/test/TestAPSP.java
@@ -35,6 +35,7 @@ import java.io.*;
 import java.util.Iterator;
 
 import org.graphstream.algorithm.*;
+import org.graphstream.algorithm.APSP.APSPInfo;
 import org.graphstream.graph.*;
 import org.graphstream.graph.implementations.SingleGraph;
 import org.graphstream.stream.*;
@@ -76,12 +77,8 @@ public class TestAPSP {
 		APSP apsp = new APSP(G, "weight", true);
 
 		apsp.compute();
-
-		Iterator<? extends Node> nodes = G.getNodeIterator();
-
-		while (nodes.hasNext()) {
-			Node node = nodes.next();
-
+		
+		G.nodes().forEach(node -> {
 			printNode(node);
 			/*
 			 * float Dij =
@@ -93,10 +90,10 @@ public class TestAPSP {
 			 */
 
 			node.setAttribute("label", node.getId());
-		}
+		});
 
 		if (G.getNode("A") != null && G.getNode("E") != null) {
-			APSP.APSPInfo info = G.getNode("A").getAttribute(
+			APSP.APSPInfo info = (APSPInfo) G.getNode("A").getAttribute(
 					APSP.APSPInfo.ATTRIBUTE_NAME);
 			Path path = info.getShortestPathTo("E");
 
@@ -125,7 +122,7 @@ public class TestAPSP {
 		Node D = G.getNode("D");
 		Node E = G.getNode("E");
 
-		APSP.APSPInfo info = A.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
+		APSP.APSPInfo info = (APSPInfo) A.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
 		Path path = info.getShortestPathTo("E");
 		Object npath[] = path.getNodePath().toArray();
 		Object npath1[] = { A, B, C, D, E };
@@ -145,7 +142,7 @@ public class TestAPSP {
 		assertEquals(3, path.getNodeCount(), 0);
 		assertArrayEquals(npath2, npath);
 
-		info = E.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
+		info = (APSPInfo) E.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
 		path = info.getShortestPathTo("C");
 		npath = path.getNodePath().toArray();
 		Object npath3[] = { E, D, B, C };
@@ -174,7 +171,7 @@ public class TestAPSP {
 		Node C = G.getNode("C");
 		Node D = G.getNode("D");
 
-		APSP.APSPInfo info = A.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
+		APSP.APSPInfo info = (APSPInfo) A.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
 		Path path = info.getShortestPathTo("C");
 		Object npath[] = path.getNodePath().toArray();
 		Object npath1[] = { A, D, C };
@@ -186,7 +183,7 @@ public class TestAPSP {
 		assertEquals(2.0, info.getLengthTo("C"), 0);
 		assertEquals(1.0, info.getLengthTo("D"), 0);
 
-		info = B.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
+		info = (APSPInfo) B.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
 		path = info.getShortestPathTo("C");
 		npath = path.getNodePath().toArray();
 		Object npath2[] = { B, A, D, C };
@@ -216,7 +213,7 @@ public class TestAPSP {
 		Node D = G.getNode("D");
 		Node E = G.getNode("E");
 
-		APSP.APSPInfo info = A.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
+		APSP.APSPInfo info = (APSPInfo) A.getAttribute(APSP.APSPInfo.ATTRIBUTE_NAME);
 		Path path = info.getShortestPathTo("B");
 		Object npath[] = path.getNodePath().toArray();
 		Object npath1[] = { A, D, B }; // ? Or A, D, E, B ? There are two paths.

--- a/src-test/org/graphstream/algorithm/test/TestBetweenessCentrality.java
+++ b/src-test/org/graphstream/algorithm/test/TestBetweenessCentrality.java
@@ -31,16 +31,15 @@
  */
 package org.graphstream.algorithm.test;
 
+import static org.junit.Assert.assertEquals;
+
 import java.util.Collection;
 
 import org.graphstream.algorithm.BetweennessCentrality;
-import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Node;
 import org.graphstream.graph.implementations.SingleGraph;
-
 import org.junit.Test;
-import static org.junit.Assert.*;
 
 public class TestBetweenessCentrality {
 
@@ -112,8 +111,8 @@ public class TestBetweenessCentrality {
 	}
 
 	protected void testIfWeightedAndUnweightedAreEqual(Graph graph1, Graph graph2, BetweennessCentrality bcb) {
-		for(Edge edge:graph1.getEachEdge()) { edge.setAttribute("weight", 1); }
-		for(Edge edge:graph2.getEachEdge()) { edge.setAttribute("weight", 1); }
+		graph1.edges().forEach(edge -> edge.setAttribute("weight", 1));
+		graph2.edges().forEach(edge -> edge.setAttribute("weight", 1));
 		bcb.setUnweighted();
 		bcb.init(graph1);
 		bcb.compute();

--- a/src-test/org/graphstream/algorithm/test/TestDijkstra.java
+++ b/src-test/org/graphstream/algorithm/test/TestDijkstra.java
@@ -82,10 +82,10 @@ public class TestDijkstra {
 		g.addEdge("CF", "C", "F").setAttribute("length", 11);
 		g.addEdge("DF", "D", "F").setAttribute("length", 15);
 		g.addEdge("EF", "E", "F").setAttribute("length", 6);
-		for (Node n : g)
-			n.setAttribute("label", n.getId());
-		for (Edge e : g.getEachEdge())
-			e.setAttribute("label", "" + (int) e.getNumber("length"));
+		
+		g.nodes().forEach(n -> n.setAttribute("label", n.getId()));
+		g.edges().forEach(e -> e.setAttribute("label", "" + (int) e.getNumber("length")));
+		
 		return g;
 	}
 	
@@ -150,8 +150,8 @@ public class TestDijkstra {
 			assertEquals(nodesAE[3 - i], ln.get(i).getId());
 		
 		// There is no path A->G
-		assertFalse(d.getPathNodesIterator(g.getNode("G")).hasNext());
-		assertFalse(d.getPathEdgesIterator(g.getNode("G")).hasNext());
+		assertFalse(d.getPathNodesStream(g.getNode("G")).iterator().hasNext());
+		assertFalse(d.getPathEdgesStream(g.getNode("G")).iterator().hasNext());
 		
 		d.clear();
 		assertFalse(source.hasAttribute("result"));
@@ -196,6 +196,6 @@ public class TestDijkstra {
 		assertTrue(lp.contains("[A, B, F]"));
 		
 		// and don't forget the special case G
-		assertFalse(d.getAllPathsIterator(g.getNode("G")).hasNext());
+		assertFalse(d.getAllPathsStream(g.getNode("G")).iterator().hasNext());
 	}
 }

--- a/src/org/graphstream/algorithm/APSP.java
+++ b/src/org/graphstream/algorithm/APSP.java
@@ -34,7 +34,6 @@ package org.graphstream.algorithm;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.concurrent.atomic.DoubleAccumulator;
-import java.util.function.DoubleBinaryOperator;
 import java.util.stream.Stream;
 
 import org.graphstream.graph.Edge;
@@ -396,8 +395,7 @@ public class APSP extends SinkAdapter implements Algorithm {
 			// The Floyd-Warshall algorithm. You can easily see it is in O(n^3)..
 
 			// int z = 0;
-			DoubleBinaryOperator op = (x, y) -> x + y;
-			DoubleAccumulator prog = new DoubleAccumulator(op, 0);
+			DoubleAccumulator prog = new DoubleAccumulator((x, y) -> x + y, 0);
 			final double MAX  = nodeList.size() * nodeList.size();
 			
 			nodeList.stream().forEach(k -> {

--- a/src/org/graphstream/algorithm/AStar.java
+++ b/src/org/graphstream/algorithm/AStar.java
@@ -433,40 +433,7 @@ public class AStar implements Algorithm {
 				closed.put(current.node, current);
 
 				// For each successor of the current node :
-				/*
-				// Iterator
-				Iterator<? extends Edge> nexts = current.node
-						.getLeavingEdgeIterator();
-
-				while (nexts.hasNext()) {
-					Edge edge = nexts.next();
-					Node next = edge.getOpposite(current.node);
-					double h = costs.heuristic(next, targetNode);
-					double g = current.g + costs.cost(current.node, edge, next);
-					double f = g + h;
-
-					// If the node is already in open with a better rank, we
-					// skip it.
-
-					AStarNode alreadyInOpen = open.get(next);
-
-					if (alreadyInOpen != null && alreadyInOpen.rank <= f)
-						continue;
-
-					// If the node is already in closed with a better rank; we
-					// skip it.
-
-					AStarNode alreadyInClosed = closed.get(next);
-
-					if (alreadyInClosed != null && alreadyInClosed.rank <= f)
-						continue;
-
-					closed.remove(next);
-					open.put(next, new AStarNode(next, edge, current, g, h));
-				}
-				*/
 				
-				// Stream
 				current.node.leavingEdges().forEach(edge -> {
 					Node next = edge.getOpposite(current.node);
 					double h = costs.heuristic(next, targetNode);
@@ -508,20 +475,6 @@ public class AStar implements Algorithm {
 		double min = Float.MAX_VALUE;
 		AStarNode theChosenOne = null;
 		
-		/*
-		// Iterator
-		for (AStarNode node : open.values()) {
-			if (node.rank < min) {
-				theChosenOne = node;
-				min = node.rank;
-			}
-		}
-		
-		System.out.println("theChosenOne : "+theChosenOne.node.getId());
-		System.out.println("min : "+min);
-		*/
-		
-		// Stream
 		theChosenOne = open.values().stream()
 				.min((n,m) -> Double.compare(n.rank, m.rank))
 				.get();

--- a/src/org/graphstream/algorithm/AStar.java
+++ b/src/org/graphstream/algorithm/AStar.java
@@ -470,15 +470,12 @@ public class AStar implements Algorithm {
 		// The problem is that we use open has a hash to ensure
 		// a node we will add to to open is not yet in it.
 
-		double min = Float.MAX_VALUE;
 		AStarNode theChosenOne = null;
 		
 		theChosenOne = open.values().stream()
 				.min((n,m) -> Double.compare(n.rank, m.rank))
 				.get();
 		
-		min = theChosenOne.rank ;
-
 		return theChosenOne;
 	}
 

--- a/src/org/graphstream/algorithm/AStar.java
+++ b/src/org/graphstream/algorithm/AStar.java
@@ -31,13 +31,11 @@
  */
 package org.graphstream.algorithm;
 
-import static org.graphstream.algorithm.Toolkit.edgeLength;
-import static org.graphstream.algorithm.Toolkit.nodePosition;
+import static org.graphstream.ui.graphicGraph.GraphPosLengthUtils.edgeLength;
+import static org.graphstream.ui.graphicGraph.GraphPosLengthUtils.nodePosition;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map.Entry;
 
 import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;

--- a/src/org/graphstream/algorithm/AbstractSpanningTree.java
+++ b/src/org/graphstream/algorithm/AbstractSpanningTree.java
@@ -32,6 +32,7 @@
 package org.graphstream.algorithm;
 
 import java.util.Iterator;
+import java.util.stream.Stream;
 
 import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
@@ -282,16 +283,17 @@ public abstract class AbstractSpanningTree implements SpanningTree {
 	/* (non-Javadoc)
 	 * @see org.graphstream.algorithm.SpanningTree#getTreeEdgesIterator()
 	 */
-	public abstract <T extends Edge> Iterator<T> getTreeEdgesIterator();
+	public abstract Stream<Edge> getTreeEdgesStream();
 
 	/* (non-Javadoc)
 	 * @see org.graphstream.algorithm.SpanningTree#getTreeEdges()
 	 */
-	public <T extends Edge> Iterable<T> getTreeEdges() {
-		return new Iterable<T>() {
-			public Iterator<T> iterator() {
-				return getTreeEdgesIterator();
+	public Iterable<Edge> getTreeEdges() {
+		return new Iterable<Edge>() {
+			public Iterator<Edge> iterator() {
+				return getTreeEdgesStream().iterator();
 			}
+			
 		};
 	}
 

--- a/src/org/graphstream/algorithm/BellmanFord.java
+++ b/src/org/graphstream/algorithm/BellmanFord.java
@@ -331,10 +331,6 @@ public class BellmanFord implements Algorithm {
 	}
 
 	
-	
-	
-	
-	
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -351,18 +347,7 @@ public class BellmanFord implements Algorithm {
 			else
 				n.setAttribute(identifier+".distance", Double.POSITIVE_INFINITY);
 		});
-		
-		/*for (Node n : graph) {
-			if (n == source)
-				n.setAttribute(identifier+".distance", 0.0);
-			else
-				n.setAttribute(identifier+".distance", Double.POSITIVE_INFINITY);
-
-			//n.addAttribute(identifier+".predecessors",(Object)null);
-		}
-		*/
-	
-		
+				
 		// Step 2: relax edges repeatedly
 		graph.nodes().forEach(n -> {
 			graph.edges().forEach(e -> {
@@ -400,44 +385,8 @@ public class BellmanFord implements Algorithm {
 				}
 			});
 		});
-		/*
-		 for (int i = 0; i < graph.getNodeCount(); i++) {
-		 	for (Edge e : graph.getEachEdge()) {
-				Node n0 = e.getNode0();
-				Node n1 = e.getNode1();
-				Double d0 = (Double) n0.getAttribute(identifier+".distance");
-				Double d1 = (Double) n1.getAttribute(identifier+".distance");
+		
 
-				Double we = (Double) e.getAttribute(weightAttribute);
-				if (we == null)
-					throw new NumberFormatException(
-							"org.graphstream.algorithm.BellmanFord: Problem with attribute \""
-									+ weightAttribute + "\" on edge " + e);
-
-				if (d0 != null) {
-					if (d1 == null || d1 >= d0 + we) {
-						n1.setAttribute(identifier+".distance", d0 + we);
-						ArrayList<Edge> predecessors = (ArrayList<Edge>) n1
-								.getAttribute(identifier+".predecessors");
-
-						if (d1 != null && d1 == d0 + we) {
-							if (predecessors == null) {
-								predecessors = new ArrayList<Edge>();
-							}
-						} else {
-							predecessors = new ArrayList<Edge>();
-						}
-						if (!predecessors.contains(e)) {
-							predecessors.add(e);
-						}
-
-						n1.setAttribute(identifier+".predecessors",
-								predecessors);
-					}
-				}
-			}
-		}
-		*/
 		// Step 3: check for negative-weight cycles
 		graph.edges().forEach(e -> {
 			Node n0 = e.getNode0();
@@ -462,30 +411,5 @@ public class BellmanFord implements Algorithm {
 								BellmanFord.class.getName(), e.getId()));
 			}
 		});
-		/*
-		for (Edge e : graph.getEachEdge()) {
-			Node n0 = e.getNode0();
-			Node n1 = e.getNode1();
-			Double d0 = (Double) n0.getAttribute(identifier+".distance");
-			Double d1 = (Double) n1.getAttribute(identifier+".distance");
-
-			Double we = (Double) e.getAttribute(weightAttribute);
-
-			if (we == null) {
-				throw new NumberFormatException(
-						String.format(
-								"%s: Problem with attribute \"%s\" on edge \"%s\"",
-								BellmanFord.class.getName(), weightAttribute,
-								e.getId()));
-			}
-
-			if (d1 > d0 + we) {
-				throw new NumberFormatException(
-						String.format(
-								"%s: Problem: negative weight, cycle detected on edge \"%s\"",
-								BellmanFord.class.getName(), e.getId()));
-			}
-		}
-		*/
 	}
 }

--- a/src/org/graphstream/algorithm/BellmanFord.java
+++ b/src/org/graphstream/algorithm/BellmanFord.java
@@ -229,13 +229,12 @@ public class BellmanFord implements Algorithm {
 						.getAttribute(identifier+".predecessors");
 			}
 			if (current != source) {
-				for (Edge e : predecessors) {
+				final Node c = current ;
+				predecessors.forEach(e -> {
 					Path p = path.getACopy();
-					p.add(current, e);
-					pathSetShortestPath_facilitate(e.getOpposite(current), p,
-							paths);
-
-				}
+					p.add(c, e);
+					pathSetShortestPath_facilitate(e.getOpposite(c), p, paths);
+				});
 			}
 		}
 		if (current == source) {

--- a/src/org/graphstream/algorithm/BetweennessCentrality.java
+++ b/src/org/graphstream/algorithm/BetweennessCentrality.java
@@ -33,10 +33,11 @@ package org.graphstream.algorithm;
 
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.PriorityQueue;
 import java.util.Set;
+import java.util.concurrent.atomic.DoubleAccumulator;
+import java.util.stream.Stream;
 
 import org.graphstream.graph.Edge;
 import org.graphstream.graph.Element;
@@ -335,9 +336,9 @@ public class BetweennessCentrality implements Algorithm {
 		initAllEdges(graph);
 
 		float n = graph.getNodeCount();
-		float i = 0;
-
-		for (Node s : graph) {
+		DoubleAccumulator i = new DoubleAccumulator((x, y) -> x + y, 0);
+		
+		graph.nodes().forEach(s -> {
 			PriorityQueue<Node> S = null;
 
 			if (unweighted)
@@ -365,10 +366,10 @@ public class BetweennessCentrality implements Algorithm {
 			}
 
 			if (progress != null)
-				progress.progress(i / n);
+				progress.progress((float)i.get() / n);
 
-			i++;
-		}
+			i.accumulate(1);
+		});
 	}
 
 	/**
@@ -396,10 +397,8 @@ public class BetweennessCentrality implements Algorithm {
 			Node v = Q.removeFirst();
 
 			S.add(v);
-			Iterator<? extends Edge> ww = v.getLeavingEdgeIterator();
-
-			while (ww.hasNext()) {
-				Edge l = ww.next();
+			
+			v.leavingEdges().forEach(l -> {
 				Node w = l.getOpposite(v);//ww.next();
 
 				if (distance(w) == INFINITY) {
@@ -411,7 +410,7 @@ public class BetweennessCentrality implements Algorithm {
 					setSigma(w, sigma(w) + sigma(v));
 					addToPredecessorsOf(w, v);
 				}
-			}
+			});
 		}
 
 		return S;
@@ -447,13 +446,8 @@ public class BetweennessCentrality implements Algorithm {
 				throw new RuntimeException("negative distance ??");
 			} else {
 				S.add(u);
-
-//				Iterator<? extends Node> k = u.getNeighborNodeIterator();
-				Iterator<? extends Edge> k = u.getLeavingEdgeIterator();
-
-				while (k.hasNext()) {
-//					Node v = k.next();
-					Edge l = k.next();
+				
+				u.leavingEdges().forEach(l -> {
 					Node v = l.getOpposite(u);
 					
 					double alt = distance(u) + weight(u, v);
@@ -478,7 +472,7 @@ public class BetweennessCentrality implements Algorithm {
 						setSigma(v, sigma(v) + sigma(u));
 						addToPredecessorsOf(v, u);
 					}
-				}
+				});
 			}
 		}
 
@@ -519,11 +513,8 @@ public class BetweennessCentrality implements Algorithm {
 			S.add(v);
 
 			//Iterator<? extends Node> k = v.getNeighborNodeIterator();
-			Iterator<? extends Edge> k = v.getLeavingEdgeIterator();
-
-			while (k.hasNext()) {
-				//Node w = k.next();
-				Edge l = k.next();
+			
+			v.leavingEdges().forEach(l -> {
 				Node w = l.getOpposite(v);
 				
 				double alt = distance(v) + weight(v, w);
@@ -543,7 +534,7 @@ public class BetweennessCentrality implements Algorithm {
 					setSigma(w, sigma(w) + sigma(v));
 					addToPredecessorsOf(w, v);
 				}
-			}
+			});
 		}
 
 		return S;
@@ -757,9 +748,7 @@ public class BetweennessCentrality implements Algorithm {
 	 *            The graph to modify.
 	 */
 	protected void initAllNodes(Graph graph) {
-		for (Node node : graph) {
-			setCentrality(node, 0.0);
-		}
+		graph.nodes().forEach(node -> setCentrality(node, 0.0));
 	}
 	
 	/**
@@ -770,9 +759,7 @@ public class BetweennessCentrality implements Algorithm {
 	 */
 	protected void initAllEdges(Graph graph) {
 		if(doEdges) {
-			for(Edge edge : graph.getEachEdge()) {
-				setCentrality(edge, 0.0);
-			}
+			graph.edges().forEach(edge -> setCentrality(edge, 0.0));
 		}
 	}
 
@@ -795,30 +782,31 @@ public class BetweennessCentrality implements Algorithm {
 	 * Delete attributes used by this algorithm in nodes and edges of the graph
 	 */
 	public void cleanGraph(){
-		cleanElement(graph.getEachEdge());
-		cleanElement(graph.getEachNode());
+		cleanElement(graph.edges());
+		cleanElement(graph.nodes());
 	}
 
 	/**
 	 * Delete attributes used by this algorithm in nodes of the graph
 	 */
 	public void cleanNodes(){
-		cleanElement(graph.getEachNode());
+		cleanElement(graph.nodes());
 	}
 
 	/**
 	 * Delete attributes used by this algorithm in edges of the graph
 	 */
 	public void cleanEdges(){
-		cleanElement(graph.getEachEdge());
+		cleanElement(graph.edges());
 	}
 
 	/**
 	 * Delete attributes used by this algorithm in elements of a graph
 	 * @param it the list of elements
 	 */
-	private void cleanElement(Iterable<? extends Element> it){
-		for(Element e : it){
+	private void cleanElement(Stream<? extends Element> st){
+		
+		st.forEach(e -> {
 			if(e.hasAttribute(predAttributeName))
 				e.removeAttribute(predAttributeName);
 			if(e.hasAttribute(sigmaAttributeName))
@@ -827,7 +815,7 @@ public class BetweennessCentrality implements Algorithm {
 				e.removeAttribute(distAttributeName);
 			if(e.hasAttribute(deltaAttributeName))
 				e.removeAttribute(deltaAttributeName);
-		}
+		});
 	}
 
 	/**

--- a/src/org/graphstream/algorithm/ConnectedComponents.java
+++ b/src/org/graphstream/algorithm/ConnectedComponents.java
@@ -41,6 +41,7 @@ import java.util.stream.Stream;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Edge;
 import org.graphstream.graph.Node;
+import org.graphstream.graph.Structure;
 import org.graphstream.stream.SinkAdapter;
 
 /**
@@ -633,7 +634,7 @@ public class ConnectedComponents extends SinkAdapter
 			}
 		}
 	}
-
+	
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -724,7 +725,7 @@ public class ConnectedComponents extends SinkAdapter
 	 * algorithm.
 	 *
 	 */
-	public class ConnectedComponent {
+	public class ConnectedComponent implements Structure {
 		/**
 		 * The unique id of this component.
 		 * 
@@ -764,19 +765,17 @@ public class ConnectedComponents extends SinkAdapter
 			}
 		}
 
-
-		public Stream<Node> stream() {
-			return graph.nodes().filter(n -> componentsMap.get(n) == ConnectedComponent.this ) ;
-		}
-
 		/**
 		 * Return an stream over the nodes of this component.
 		 * 
 		 * @return an stream over the nodes of this component
 		 */
-		public Stream<Node> getEachNode() {
-			return stream();
+		
+		public Stream<Node> nodes() {
+			return graph.nodes().filter(n -> componentsMap.get(n) == ConnectedComponent.this ) ;
 		}
+
+		
 
 		/**
 		 * Get a set containing all the nodes of this component.
@@ -788,7 +787,7 @@ public class ConnectedComponents extends SinkAdapter
 		public Set<Node> getNodeSet() {
 			HashSet<Node> nodes = new HashSet<Node>();
 			
-			stream().forEach(n -> nodes.add(n));
+			nodes().forEach(n -> nodes.add(n));
 			
 			return nodes;
 		}
@@ -802,18 +801,7 @@ public class ConnectedComponents extends SinkAdapter
 		 * 
 		 * @return an stream over the edges of this component
 		 */
-		public Stream<Edge> getEachEdge() {
-			return getEdgeStream();
-		}
-
-		/**
-		 * The stream over the edges of this component.
-		 * 
-		 * See {@see #getEachEdge()} for details.
-		 * 
-		 * @return stream over the edges of this component
-		 */
-		public Stream<Edge> getEdgeStream() {
+		public Stream<Edge> edges() {
 			return graph.edges().filter(e -> {
 				return (componentsMap.get(e.getNode0()) == ConnectedComponent.this)
 						&& (componentsMap.get(e.getNode1()) == ConnectedComponent.this)
@@ -840,6 +828,18 @@ public class ConnectedComponents extends SinkAdapter
 		@Override
 		public String toString() {
 			return String.format("ConnectedComponent#%d", id);
+		}
+
+		@Override
+		public int getNodeCount() {
+			// TODO Auto-generated method stub
+			return (int) nodes().count();
+		}
+
+		@Override
+		public int getEdgeCount() {
+			// TODO Auto-generated method stub
+			return (int) edges().count();
 		}
 	}
 }

--- a/src/org/graphstream/algorithm/DStar.java
+++ b/src/org/graphstream/algorithm/DStar.java
@@ -242,7 +242,7 @@ public class DStar implements DynamicAlgorithm, Sink {
 	}
 
 	public State getState(Node n) {
-		State s = n.getAttribute(STATE_ATTRIBUTE);
+		State s = (State) n.getAttribute(STATE_ATTRIBUTE);
 
 		if (s == null) {
 			s = new State(n);
@@ -299,11 +299,8 @@ public class DStar implements DynamicAlgorithm, Sink {
 	}
 
 	public void markPath(String attribute, Object on, Object off) {
-		for (Node n : env)
-			n.setAttribute(attribute, off);
-
-		for (Edge e : env.getEachEdge())
-			e.setAttribute(attribute, off);
+		env.nodes().forEach(n -> n.setAttribute(attribute, off));
+		env.edges().forEach(e -> e.setAttribute(attribute, off));
 
 		State s = position;
 

--- a/src/org/graphstream/algorithm/Dijkstra.java
+++ b/src/org/graphstream/algorithm/Dijkstra.java
@@ -35,7 +35,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.Spliterator;
+import java.util.Spliterators;
 import java.util.Stack;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.graphstream.algorithm.util.FibonacciHeap;
 import org.graphstream.graph.Edge;
@@ -305,14 +309,14 @@ public class Dijkstra extends AbstractSpanningTree {
 	@Override
 	public void clear() {
 		super.clear();
-		for (Node node : graph) {
-			Data data = node.getAttribute(resultAttribute);
+		graph.nodes().forEach(node -> {
+			Data data = (Data) node.getAttribute(resultAttribute);
 			if (data != null) {
 				data.fn = null;
 				data.edgeFromParent = null;
 			}
 			node.removeAttribute(resultAttribute);
-		}
+		});
 	}
 
 	// *** Methods of Algorithm interface ***
@@ -348,40 +352,43 @@ public class Dijkstra extends AbstractSpanningTree {
 	protected void makeTree() {
 		// initialization
 		FibonacciHeap<Double, Node> heap = new FibonacciHeap<Double, Node>();
-		for (Node node : graph) {
+		
+		graph.nodes().forEach(node -> {
 			Data data = new Data();
 			double v = node == source ? getSourceLength()
 					: Double.POSITIVE_INFINITY;
 			data.fn = heap.add(v, node);
 			data.edgeFromParent = null;
 			node.setAttribute(resultAttribute, data);
-		}
+		});
 
 		// main loop
 		while (!heap.isEmpty()) {
 			Node u = heap.extractMin();
-			Data dataU = u.getAttribute(resultAttribute);
+			Data dataU = (Data) u.getAttribute(resultAttribute);
 			dataU.distance = dataU.fn.getKey();
 			dataU.fn = null;
 			if (dataU.edgeFromParent != null)
 				edgeOn(dataU.edgeFromParent);
-			for (Edge e : u.getEachLeavingEdge()) {
+			
+			u.leavingEdges()
+				.filter(e -> ((Data) e.getOpposite(u).getAttribute(resultAttribute)).fn != null)
+				.forEach(e -> {
 				Node v = e.getOpposite(u);
-				Data dataV = v.getAttribute(resultAttribute);
-				if (dataV.fn == null)
-					continue;
+				Data dataV = (Data) v.getAttribute(resultAttribute);
+			
 				double tryDist = dataU.distance + getLength(e, v);
 				if (tryDist < dataV.fn.getKey()) {
 					dataV.edgeFromParent = e;
 					heap.decreaseKey(dataV.fn, tryDist);
 				}
-			}
+			});
 		}		
 	}
 
 	// *** Iterators ***
 
-	protected class NodeIterator<T extends Node> implements Iterator<T> {
+	protected class NodeIterator implements Iterator<Node> {
 		protected Node nextNode;
 
 		protected NodeIterator(Node target) {
@@ -392,13 +399,12 @@ public class Dijkstra extends AbstractSpanningTree {
 			return nextNode != null;
 		}
 
-		@SuppressWarnings("unchecked")
-		public T next() {
+		public Node next() {
 			if (nextNode == null)
 				throw new NoSuchElementException();
 			Node node = nextNode;
 			nextNode = getParent(nextNode);
-			return (T) node;
+			return node;
 		}
 
 		public void remove() {
@@ -407,9 +413,9 @@ public class Dijkstra extends AbstractSpanningTree {
 		}
 	}
 
-	protected class EdgeIterator<T extends Edge> implements Iterator<T> {
+	protected class EdgeIterator implements Iterator<Edge> {
 		protected Node nextNode;
-		protected T nextEdge;
+		protected Edge nextEdge;
 
 		protected EdgeIterator(Node target) {
 			nextNode = target;
@@ -420,10 +426,10 @@ public class Dijkstra extends AbstractSpanningTree {
 			return nextEdge != null;
 		}
 
-		public T next() {
+		public Edge next() {
 			if (nextEdge == null)
 				throw new NoSuchElementException();
-			T edge = nextEdge;
+			Edge edge = nextEdge;
 			nextNode = getParent(nextNode);
 			nextEdge = getEdgeFromParent(nextNode);
 			return edge;
@@ -450,7 +456,7 @@ public class Dijkstra extends AbstractSpanningTree {
 				Node u = e.getOpposite(v);
 				if (getPathLength(u) + getLength(e, v) == lengthV) {
 					nodes.add(u);
-					iterators.add(u.getEnteringEdgeIterator());
+					iterators.add(u.enteringEdges().iterator());
 					return;
 				}
 			}
@@ -483,7 +489,7 @@ public class Dijkstra extends AbstractSpanningTree {
 				return;
 			}
 			nodes.add(target);
-			iterators.add(target.getEnteringEdgeIterator());
+			iterators.add(target.enteringEdges().iterator());
 			extendPath();
 			constructNextPath();
 		}
@@ -509,9 +515,9 @@ public class Dijkstra extends AbstractSpanningTree {
 		}
 	}
 
-	protected class TreeIterator<T extends Edge> implements Iterator<T> {
+	protected class TreeIterator implements Iterator<Edge> {
 		Iterator<Node> nodeIt;
-		T nextEdge;
+		Edge nextEdge;
 
 		protected void findNextEdge() {
 			nextEdge = null;
@@ -520,7 +526,7 @@ public class Dijkstra extends AbstractSpanningTree {
 		}
 
 		protected TreeIterator() {
-			nodeIt = graph.getNodeIterator();
+			nodeIt = graph.nodes().iterator();
 			findNextEdge();
 		}
 
@@ -528,10 +534,10 @@ public class Dijkstra extends AbstractSpanningTree {
 			return nextEdge != null;
 		}
 
-		public T next() {
+		public Edge next() {
 			if (nextEdge == null)
 				throw new NoSuchElementException();
-			T edge = nextEdge;
+			Edge edge = nextEdge;
 			findNextEdge();
 			return edge;
 		}
@@ -556,7 +562,7 @@ public class Dijkstra extends AbstractSpanningTree {
 	 * @complexity O(1)
 	 */
 	public double getPathLength(Node target) {
-		return target.<Data> getAttribute(resultAttribute).distance;
+		return ((Data)target.getAttribute(resultAttribute)).distance;
 	}
 
 	/**
@@ -591,9 +597,8 @@ public class Dijkstra extends AbstractSpanningTree {
 	 * @see #getParent(Node)
 	 * @complexity O(1)
 	 */
-	@SuppressWarnings("unchecked")
-	public <T extends Edge> T getEdgeFromParent(Node target) {
-		return (T) target.<Data> getAttribute(resultAttribute).edgeFromParent;
+	public Edge getEdgeFromParent(Node target) {
+		return ((Data) target.getAttribute(resultAttribute)).edgeFromParent;
 	}
 
 	/**
@@ -609,7 +614,7 @@ public class Dijkstra extends AbstractSpanningTree {
 	 * @see #getEdgeFromParent(Node)
 	 * @complexity O(1)
 	 */
-	public <T extends Node> T getParent(Node target) {
+	public Node getParent(Node target) {
 		Edge edge = getEdgeFromParent(target);
 		if (edge == null)
 			return null;
@@ -632,8 +637,13 @@ public class Dijkstra extends AbstractSpanningTree {
 	 * @complexity Each call of {@link java.util.Iterator#next()} of this
 	 *             iterator takes O(1) time
 	 */
-	public <T extends Node> Iterator<T> getPathNodesIterator(Node target) {
-		return new NodeIterator<T>(target);
+	public Stream<Node> getPathNodesStream(Node target) {
+		return StreamSupport.stream(
+		    	Spliterators.spliteratorUnknownSize(
+		    			new NodeIterator(target),
+		                Spliterator.DISTINCT |
+		                Spliterator.IMMUTABLE |
+		                Spliterator.NONNULL), false);
 	}
 
 	/**
@@ -646,10 +656,10 @@ public class Dijkstra extends AbstractSpanningTree {
 	 *         source to the target
 	 * @see #getPathNodesIterator(Node)
 	 */
-	public <T extends Node> Iterable<T> getPathNodes(final Node target) {
-		return new Iterable<T>() {
-			public Iterator<T> iterator() {
-				return getPathNodesIterator(target);
+	public Iterable<Node> getPathNodes(final Node target) {
+		return new Iterable<Node>() {
+			public Iterator<Node> iterator() {
+				return getPathNodesStream(target).iterator();
 			}
 		};
 	}
@@ -671,8 +681,14 @@ public class Dijkstra extends AbstractSpanningTree {
 	 * @complexity Each call of {@link java.util.Iterator#next()} of this
 	 *             iterator takes O(1) time
 	 */
-	public <T extends Edge> Iterator<T> getPathEdgesIterator(Node target) {
-		return new EdgeIterator<T>(target);
+	public Stream<Edge> getPathEdgesStream(Node target) {
+		return StreamSupport.stream(
+		    	Spliterators.spliteratorUnknownSize(
+		    			new EdgeIterator(target),
+		                Spliterator.DISTINCT |
+		                Spliterator.IMMUTABLE |
+		                Spliterator.NONNULL), false);
+		
 	}
 
 	/**
@@ -685,10 +701,10 @@ public class Dijkstra extends AbstractSpanningTree {
 	 *         source to the target
 	 * @see #getPathEdgesIterator(Node)
 	 */
-	public <T extends Edge> Iterable<T> getPathEdges(final Node target) {
-		return new Iterable<T>() {
-			public Iterator<T> iterator() {
-				return getPathEdgesIterator(target);
+	public Iterable<Edge> getPathEdges(final Node target) {
+		return new Iterable<Edge>() {
+			public Iterator<Edge> iterator() {
+				return getPathEdgesStream(target).iterator();
 			}
 
 		};
@@ -713,8 +729,13 @@ public class Dijkstra extends AbstractSpanningTree {
 	 *             iterator takes O(<em>m</em>) time in the worst case, where
 	 *             <em>m</em> is the number of edges in the graph
 	 */
-	public Iterator<Path> getAllPathsIterator(Node target) {
-		return new PathIterator(target);
+	public Stream<Path> getAllPathsStream(Node target) {
+		return StreamSupport.stream(
+		    	Spliterators.spliteratorUnknownSize(
+		    			new PathIterator(target),
+		                Spliterator.DISTINCT |
+		                Spliterator.IMMUTABLE |
+		                Spliterator.NONNULL), false);
 	}
 
 	/**
@@ -730,7 +751,7 @@ public class Dijkstra extends AbstractSpanningTree {
 	public Iterable<Path> getAllPaths(final Node target) {
 		return new Iterable<Path>() {
 			public Iterator<Path> iterator() {
-				return getAllPathsIterator(target);
+				return getAllPathsStream(target).iterator();
 			}
 		};
 	}
@@ -746,8 +767,13 @@ public class Dijkstra extends AbstractSpanningTree {
 	 *             iterator takes O(1) time
 	 */
 	@Override
-	public <T extends Edge> Iterator<T> getTreeEdgesIterator() {
-		return new TreeIterator<T>();
+	public Stream<Edge> getTreeEdgesStream() {
+		return StreamSupport.stream(
+		    	Spliterators.spliteratorUnknownSize(
+		    			new TreeIterator(),
+		                Spliterator.DISTINCT |
+		                Spliterator.IMMUTABLE |
+		                Spliterator.NONNULL), false);
 	}
 
 
@@ -770,8 +796,9 @@ public class Dijkstra extends AbstractSpanningTree {
 		if (Double.isInfinite(getPathLength(target)))
 			return path;
 		Stack<Edge> stack = new Stack<Edge>();
-		for (Edge e : getPathEdges(target))
-			stack.push(e);
+		
+		getPathEdges(target).forEach(e -> stack.push(e));
+			
 		path.setRoot(source);
 		while (!stack.isEmpty())
 			path.add(stack.pop());

--- a/src/org/graphstream/algorithm/Dijkstra.java
+++ b/src/org/graphstream/algorithm/Dijkstra.java
@@ -659,7 +659,7 @@ public class Dijkstra extends AbstractSpanningTree {
 	public Iterable<Node> getPathNodes(final Node target) {
 		return new Iterable<Node>() {
 			public Iterator<Node> iterator() {
-				return getPathNodesStream(target).iterator();
+				return new NodeIterator(target);
 			}
 		};
 	}
@@ -704,7 +704,7 @@ public class Dijkstra extends AbstractSpanningTree {
 	public Iterable<Edge> getPathEdges(final Node target) {
 		return new Iterable<Edge>() {
 			public Iterator<Edge> iterator() {
-				return getPathEdgesStream(target).iterator();
+				return new EdgeIterator(target);
 			}
 
 		};
@@ -751,7 +751,7 @@ public class Dijkstra extends AbstractSpanningTree {
 	public Iterable<Path> getAllPaths(final Node target) {
 		return new Iterable<Path>() {
 			public Iterator<Path> iterator() {
-				return getAllPathsStream(target).iterator();
+				return new PathIterator(target);
 			}
 		};
 	}

--- a/src/org/graphstream/algorithm/Kruskal.java
+++ b/src/org/graphstream/algorithm/Kruskal.java
@@ -37,6 +37,11 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
 
 import org.graphstream.algorithm.util.DisjointSets;
 import org.graphstream.graph.Edge;
@@ -213,7 +218,7 @@ public class Kruskal extends AbstractSpanningTree {
 		else
 			treeEdges.clear();
 
-		List<Edge> sortedEdges = new ArrayList<Edge>(graph.getEdgeSet());
+		List<Edge> sortedEdges = new ArrayList<Edge>(graph.edges().collect(Collectors.toList()));
 		Collections.sort(sortedEdges, new EdgeComparator());
 		
 		DisjointSets<Node> components = new DisjointSets<Node>(
@@ -235,8 +240,13 @@ public class Kruskal extends AbstractSpanningTree {
 	}
 
 	@Override
-	public <T extends Edge> Iterator<T> getTreeEdgesIterator() {
-		return new TreeIterator<T>();
+	public Stream<Edge> getTreeEdgesStream() {
+		return StreamSupport.stream(
+		    	Spliterators.spliteratorUnknownSize(
+		    			new TreeIterator(),
+		                Spliterator.DISTINCT |
+		                Spliterator.IMMUTABLE |
+		                Spliterator.NONNULL), false);
 	}
 
 	@Override
@@ -277,7 +287,7 @@ public class Kruskal extends AbstractSpanningTree {
 		}
 	}
 
-	protected class TreeIterator<T extends Edge> implements Iterator<T> {
+	protected class TreeIterator implements Iterator<Edge> {
 
 		protected Iterator<Edge> it = treeEdges.iterator();
 
@@ -285,9 +295,8 @@ public class Kruskal extends AbstractSpanningTree {
 			return it.hasNext();
 		}
 
-		@SuppressWarnings("unchecked")
-		public T next() {
-			return (T) it.next();
+		public Edge next() {
+			return it.next();
 		}
 
 		public void remove() {

--- a/src/org/graphstream/algorithm/PageRank.java
+++ b/src/org/graphstream/algorithm/PageRank.java
@@ -311,8 +311,9 @@ public class PageRank implements DynamicAlgorithm, ElementSink {
 		this.graph = graph;
 		graph.addElementSink(this);
 		double initialRank = 1.0 / graph.getNodeCount();
-		for (Node node : graph)
-			node.setAttribute(rankAttribute, initialRank);
+		
+		graph.nodes().forEach(node -> node.setAttribute(rankAttribute, initialRank));
+		
 		newRanks = new ArrayList<Double>(graph.getNodeCount());
 		upToDate = false;
 		iterationCount = 0;
@@ -349,10 +350,11 @@ public class PageRank implements DynamicAlgorithm, ElementSink {
 		// removed node will give equal parts of its rank to the others
 		double part = graph.getNode(nodeId).getNumber(rankAttribute)
 				/ (graph.getNodeCount() - 1);
-		for (Node node : graph)
-			if (!node.getId().equals(nodeId))
-				node.setAttribute(rankAttribute, node.getNumber(rankAttribute)
-						+ part);
+		
+		graph.nodes()
+			.filter(node -> !node.getId().equals(nodeId))
+			.forEach(node -> node.setAttribute(rankAttribute, node.getNumber(rankAttribute) + part));
+		
 		upToDate = false;
 	}
 

--- a/src/org/graphstream/algorithm/Prim.java
+++ b/src/org/graphstream/algorithm/Prim.java
@@ -188,17 +188,19 @@ public class Prim extends Kruskal {
 				dataU.edgeToTree = null;
 			}
 			dataU.fn = null;
-			for (Edge e : u) {
-				Node v = e.getOpposite(u);
-				Data dataV = data[v.getIndex()];
-				if (dataV == null)
-					continue;
-				double w = getWeight(e);
-				if (w < dataV.fn.getKey()) {
-					heap.decreaseKey(dataV.fn, w);
-					dataV.edgeToTree = e;
-				}
-			}
+			
+			u.edges()
+				.filter(e -> data[e.getOpposite(u).getIndex()] != null)
+				.forEach(e -> {
+					Node v = e.getOpposite(u);
+					Data dataV = data[v.getIndex()];
+					
+					double w = getWeight(e);
+					if (w < dataV.fn.getKey()) {
+						heap.decreaseKey(dataV.fn, w);
+						dataV.edgeToTree = e;
+					}
+				});
 		}
 	}
 

--- a/src/org/graphstream/algorithm/SpanningTree.java
+++ b/src/org/graphstream/algorithm/SpanningTree.java
@@ -31,7 +31,7 @@
  */
 package org.graphstream.algorithm;
 
-import java.util.Iterator;
+import java.util.stream.Stream;
 
 import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
@@ -107,7 +107,7 @@ public interface SpanningTree extends Algorithm {
 	 * 
 	 * @return An iterator on the tree edges
 	 */
-	<T extends Edge> Iterator<T> getTreeEdgesIterator();
+	Stream<Edge> getTreeEdgesStream();
 	
 	
 	/**

--- a/src/org/graphstream/algorithm/TarjanStronglyConnectedComponents.java
+++ b/src/org/graphstream/algorithm/TarjanStronglyConnectedComponents.java
@@ -34,7 +34,6 @@ package org.graphstream.algorithm;
 import java.util.HashMap;
 import java.util.Stack;
 
-import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Node;
 
@@ -145,11 +144,11 @@ public class TarjanStronglyConnectedComponents implements Algorithm {
 		data.clear();
 		index = 0;
 		S.clear();
-
-		for (Node v : graph.getEachNode()) {
-			if (!data.containsKey(v))
-				strongConnect(v);
-		}
+		
+		graph.nodes()
+			.filter(v -> !data.containsKey(v))
+			.forEach(v -> strongConnect(v));
+		
 	}
 
 	/**
@@ -201,8 +200,8 @@ public class TarjanStronglyConnectedComponents implements Algorithm {
 
 		index++;
 		S.push(v);
-
-		for (Edge vw : v.getEachLeavingEdge()) {
+		
+		v.leavingEdges().forEach(vw -> {
 			Node w = vw.getOpposite(v);
 
 			if (!data.containsKey(w)) {
@@ -211,7 +210,7 @@ public class TarjanStronglyConnectedComponents implements Algorithm {
 			} else if (S.contains(w)) {
 				nd.lowlink = Math.min(nd.lowlink, data.get(w).index);
 			}
-		}
+		});
 
 		if (nd.index == nd.lowlink) {
 			Node w;

--- a/src/org/graphstream/algorithm/community/DecentralizedCommunityAlgorithm.java
+++ b/src/org/graphstream/algorithm/community/DecentralizedCommunityAlgorithm.java
@@ -31,10 +31,15 @@
  */
 package org.graphstream.algorithm.community;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Random;
+import java.util.stream.Collectors;
 
 import org.graphstream.algorithm.DynamicAlgorithm;
-import org.graphstream.graph.*;
+import org.graphstream.graph.Element;
+import org.graphstream.graph.Graph;
+import org.graphstream.graph.Node;
 import org.graphstream.stream.Sink;
 
 /**
@@ -224,12 +229,13 @@ public abstract class DecentralizedCommunityAlgorithm implements
 		 * graph has changed since last call
 		 */
 		if (graphChanged) {
-			ArrayList<Node> nodeSet = new ArrayList<Node>(graph.getNodeSet());
+			ArrayList<Node> nodeSet = graph.nodes().collect(Collectors.toCollection(ArrayList::new));// new ArrayList<Node>(graph.getNodeSet());
 			Collections.shuffle(nodeSet, rng);
-			for (Node node : nodeSet) {
+			
+			nodeSet.forEach(node -> {
 				computeNode(node);
 				updateDisplayClass(node);
-			}
+			});
 			graphChanged = staticMode;
 		}
 	}

--- a/src/org/graphstream/algorithm/community/EpidemicCommunityAlgorithm.java
+++ b/src/org/graphstream/algorithm/community/EpidemicCommunityAlgorithm.java
@@ -34,7 +34,6 @@ package org.graphstream.algorithm.community;
 import java.util.HashMap;
 import java.util.TreeMap;
 
-import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Node;
 
@@ -131,19 +130,20 @@ public class EpidemicCommunityAlgorithm extends DecentralizedCommunityAlgorithm 
 		/*
 		 * Iterate over the nodes that this node "hears"
 		 */
-		for (Edge e : u.getEnteringEdgeSet()) {
-			Node v = e.getOpposite(u);
-
-			/*
-			 * Update the count for this community
-			 */
-			if (v.hasAttribute(marker))
+		u.enteringEdges()
+			.filter(e -> e.getOpposite(u).hasAttribute(marker))
+			.forEach(e -> {
+				/*
+				 * Update the count for this community
+				 */
+				Node v = e.getOpposite(u);
+				
 				if (communityScores.get(v.getAttribute(marker)) == null)
 					communityScores.put(v.getAttribute(marker), 1.0);
 				else
 					communityScores.put(v.getAttribute(marker),
 							communityScores.get(v.getAttribute(marker)) + 1.0);
-		}
+		});
 	}
 
 	@Override

--- a/src/org/graphstream/algorithm/community/Leung.java
+++ b/src/org/graphstream/algorithm/community/Leung.java
@@ -207,16 +207,24 @@ public class Leung extends EpidemicCommunityAlgorithm {
 		 */
 		else {
 			Double maxLabelScore = Double.NEGATIVE_INFINITY;
+			
+			// With Stream
+			maxLabelScore = node.enteringEdges()
+					.filter(e -> e.getOpposite(node).hasAttribute(marker)
+							&& e.getOpposite(node).getAttribute(marker).equals(node.getAttribute(marker)))
+					.map(e -> (Double) e.getOpposite(node).getAttribute(marker + ".score"))
+					.max((e1, e2) -> Double.compare(e1, e2))
+					.get();
+			
+			/*// With Iterator
 			for (Edge e : node.getEnteringEdgeSet()) {
 				Node v = e.getOpposite(node);
-				if (v.hasAttribute(marker)
-						&& v.getAttribute(marker).equals(
-								node.getAttribute(marker))) {
+				if (v.hasAttribute(marker)	&& v.getAttribute(marker).equals(node.getAttribute(marker))) {
 					if ((Double) v.getAttribute(marker + ".score") > maxLabelScore)
-						maxLabelScore = (Double) v.getAttribute(marker
-								+ ".score");
+						maxLabelScore = (Double) v.getAttribute(marker	+ ".score");
 				}
 			}
+			*/
 			node.setAttribute(marker + ".score", maxLabelScore - delta);
 		}
 	}
@@ -240,7 +248,7 @@ public class Leung extends EpidemicCommunityAlgorithm {
 		/*
 		 * Iterate over the nodes that this node "hears"
 		 */
-		for (Edge e : u.getEnteringEdgeSet()) {
+		u.enteringEdges().forEach(e -> {
 			Node v = e.getOpposite(u);
 
 			/*
@@ -278,7 +286,7 @@ public class Leung extends EpidemicCommunityAlgorithm {
 							communityScores.get(v.getAttribute(marker))
 									+ (score * weight));
 			}
-		}
+		});
 	}
 
 	@Override

--- a/src/org/graphstream/algorithm/community/SyncEpidemicCommunityAlgorithm.java
+++ b/src/org/graphstream/algorithm/community/SyncEpidemicCommunityAlgorithm.java
@@ -112,7 +112,7 @@ public class SyncEpidemicCommunityAlgorithm extends EpidemicCommunityAlgorithm {
 		/*
 		 * Iterate over the nodes that this node "hears"
 		 */
-		for (Edge e : u.getEnteringEdgeSet()) {
+		u.enteringEdges().forEach(e -> {
 			Node v = e.getOpposite(u);
 
 			/*
@@ -148,6 +148,6 @@ public class SyncEpidemicCommunityAlgorithm extends EpidemicCommunityAlgorithm {
 										communityScores.get(v
 												.getAttribute(syncMarker)) + 1.0);
 			}
-		}
+		});
 	}
 }

--- a/src/org/graphstream/algorithm/generator/BarabasiAlbertGenerator.java
+++ b/src/org/graphstream/algorithm/generator/BarabasiAlbertGenerator.java
@@ -224,10 +224,11 @@ public class BarabasiAlbertGenerator extends BaseGenerator {
 		for (int i = 0; i < n; i++)
 			chooseAnotherNode();
 		
-		for (int i : connected) {
+		connected.forEach(i -> {
 			addEdge(newId + "_" + i, newId, i + "");
 			degrees.set(i, degrees.get(i) + 1);
-		}
+		});
+		
 		connected.clear();
 		degrees.add(n);
 		sumDeg += 2 * n;

--- a/src/org/graphstream/algorithm/generator/BaseGenerator.java
+++ b/src/org/graphstream/algorithm/generator/BaseGenerator.java
@@ -398,16 +398,15 @@ public abstract class BaseGenerator extends SourceBase implements Generator {
 		if (useInternalGraph)
 			internalGraph.addNode(id);
 
-		double value;
-
-		for (String attr : nodeAttributes) {
-			value = (random.nextDouble() * (nodeAttributeRange[1] - nodeAttributeRange[0]))
+		nodeAttributes.forEach(attr -> {
+			double value = (random.nextDouble() * (nodeAttributeRange[1] - nodeAttributeRange[0]))
 					+ nodeAttributeRange[0];
 			sendNodeAttributeAdded(sourceId, id, attr, value);
 
 			if (useInternalGraph)
 				internalGraph.getNode(id).setAttribute(attr, value);
-		}
+		});
+		
 	}
 
 	/**
@@ -451,15 +450,17 @@ public abstract class BaseGenerator extends SourceBase implements Generator {
 
 		if (addEdgeLabels)
 			sendEdgeAttributeAdded(sourceId, id, "label", id);
-
-		for (String attr : edgeAttributes) {
+		
+		final String idFinal = id ;
+		edgeAttributes.forEach(attr -> {
 			double value = (random.nextDouble() * (edgeAttributeRange[1] - edgeAttributeRange[0]))
 					+ edgeAttributeRange[0];
-			sendEdgeAttributeAdded(sourceId, id, attr, value);
+			sendEdgeAttributeAdded(sourceId, idFinal, attr, value);
 
 			if (useInternalGraph)
-				internalGraph.getEdge(id).setAttribute(attr, value);
-		}
+				internalGraph.getEdge(idFinal).setAttribute(attr, value);
+		});
+		
 	}
 
 	/**

--- a/src/org/graphstream/algorithm/generator/FullGenerator.java
+++ b/src/org/graphstream/algorithm/generator/FullGenerator.java
@@ -31,8 +31,6 @@
  */
 package org.graphstream.algorithm.generator;
 
-import org.graphstream.graph.Node;
-
 /**
  * Full graph generator.
  * 
@@ -130,11 +128,10 @@ public class FullGenerator extends BaseGenerator {
 		String id = Integer.toString(nodeNames++);
 
 		addNode(id);
-
-		for (Node n : internalGraph.getEachNode()) {
-			if (!n.getId().equals(id)) // We can compare refs safely here.
-				addEdge(null, id, n.getId());
-		}
+		
+		internalGraph.nodes()
+			.filter(n -> !n.getId().equals(id)) // We can compare refs safely here.
+			.forEach(n -> addEdge(null, id, n.getId()));
 
 		return true;
 	}

--- a/src/org/graphstream/algorithm/generator/LCFGenerator.java
+++ b/src/org/graphstream/algorithm/generator/LCFGenerator.java
@@ -156,10 +156,9 @@ public class LCFGenerator extends BaseGenerator {
 			r++;
 		}
 
-		for (String edge : crossed) {
-			if (!added.contains(edge))
-				delEdge(edge);
-		}
+		crossed.stream()
+			.filter(edge -> !added.contains(edge))
+			.forEach(edge -> delEdge(edge));
 
 		crossed.clear();
 		crossed = added;

--- a/src/org/graphstream/algorithm/generator/LobsterGenerator.java
+++ b/src/org/graphstream/algorithm/generator/LobsterGenerator.java
@@ -163,10 +163,10 @@ public class LobsterGenerator extends BaseGenerator {
 	}
 
 	protected void delNode(Data d) {
-		for (Data c : d.connected) {
+		d.connected.forEach(c -> {
 			delEdge(getEdgeId(d, c));
 			c.connected.remove(d);
-		}
+		});
 
 		delNode(d.id);
 		nodes.remove(d);

--- a/src/org/graphstream/algorithm/generator/PointsOfInterestGenerator.java
+++ b/src/org/graphstream/algorithm/generator/PointsOfInterestGenerator.java
@@ -96,8 +96,7 @@ public class PointsOfInterestGenerator extends BaseGenerator {
 		 */
 		void newAddict(Addict addictA) {
 			if (!addict.contains(addictA)) {
-				for (Addict addictB : addict)
-					addictA.link(addictB);
+				addict.forEach(addictB -> addictA.link(addictB));
 
 				addict.add(addictA);
 				addictA.pointsOfInterest.add(this);
@@ -117,8 +116,7 @@ public class PointsOfInterestGenerator extends BaseGenerator {
 				addict.remove(addictA);
 				addictA.pointsOfInterest.remove(this);
 
-				for (Addict addictB : addict)
-					addictA.unlink(addictB);
+				addict.forEach(addictB -> addictA.unlink(addictB));
 			}
 		}
 
@@ -202,8 +200,9 @@ public class PointsOfInterestGenerator extends BaseGenerator {
 			//
 			Collections.shuffle(
 					PointsOfInterestGenerator.this.pointsOfInterest, random);
-
-			for (PointOfInterest poi : PointsOfInterestGenerator.this.pointsOfInterest) {
+			
+			
+			PointsOfInterestGenerator.this.pointsOfInterest.forEach(poi -> {
 				if (pointsOfInterest.contains(poi)) {
 					if (random.nextFloat() < lostInterestProbability)
 						poi.delAddict(this);
@@ -223,7 +222,7 @@ public class PointsOfInterestGenerator extends BaseGenerator {
 																				// )
 						poi.newAddict(this);
 				}
-			}
+			});
 		}
 
 		/**
@@ -278,11 +277,12 @@ public class PointsOfInterestGenerator extends BaseGenerator {
 		 * Unlink all neighbor.
 		 */
 		void fullUnlink() {
-			for (Addict a : neighbor.keySet()) {
+			
+			neighbor.keySet().forEach(a -> {
 				a.neighbor.remove(this);
 				PointsOfInterestGenerator.this.delEdge(getEdgeId(id, a.id));
-			}
-
+			});
+			
 			neighbor.clear();
 		}
 	}
@@ -483,8 +483,7 @@ public class PointsOfInterestGenerator extends BaseGenerator {
 	protected void removePointOfInterest(PointOfInterest poi) {
 		pointsOfInterest.remove(poi);
 
-		for (Addict a : poi.addict)
-			poi.delAddict(a);
+		poi.addict.forEach(a -> poi.delAddict(a));
 	}
 
 	protected void removeRandomPointOfInterest() {

--- a/src/org/graphstream/algorithm/generator/RandomEuclideanGenerator.java
+++ b/src/org/graphstream/algorithm/generator/RandomEuclideanGenerator.java
@@ -31,7 +31,6 @@
  */
 package org.graphstream.algorithm.generator;
 
-import org.graphstream.graph.Node;
 import org.graphstream.stream.Pipe;
 
 /**
@@ -237,10 +236,9 @@ public class RandomEuclideanGenerator extends BaseGenerator implements Pipe {
 
 		addNode(id);
 
-		for (Node n : internalGraph.getEachNode()) {
-			if (!id.equals(n.getId()) && distance(id, n.getId()) < threshold)
-				addEdge(id + "-" + n.getId(), id, n.getId());
-		}
+		internalGraph.nodes()
+			.filter(n -> !id.equals(n.getId()) && distance(id, n.getId()) < threshold)
+			.forEach(n -> addEdge(id + "-" + n.getId(), id, n.getId()));
 
 		return true;
 	}

--- a/src/org/graphstream/algorithm/generator/RandomGenerator.java
+++ b/src/org/graphstream/algorithm/generator/RandomGenerator.java
@@ -273,12 +273,12 @@ public class RandomGenerator extends BaseGenerator {
 	protected void addNewEdges(double p) {
 		RandomTools.randomPsubset(nodeCount, p, subset, random);
 		String nodeId = nodeCount + "";
-		for (int i : subset) {
+		subset.forEach(i -> {
 			String edgeId = i + "_" + nodeId;
 			addEdge(edgeId, i + "", nodeId);
 			if (allowRemove)
 				edgeIds.add(edgeId);
-		}
+		});
 	}
 
 	/**

--- a/src/org/graphstream/algorithm/generator/URLGenerator.java
+++ b/src/org/graphstream/algorithm/generator/URLGenerator.java
@@ -123,29 +123,29 @@ public class URLGenerator extends BaseGenerator {
 
 		if (printProgress)
 			progress();
-
-		for (String url : stepUrls) {
+		
+		stepUrls.forEach(url -> {
 			try {
 				addNodeURL(url);
 			} catch (URISyntaxException e) {
 				e.printStackTrace();
 			}
-		}
-
+		});
+		
 		urls.addAll(stepUrls);
 		newUrls.clear();
 
 		if (threads > 1)
 			nextEventsThreaded();
 		else {
-			for (String url : stepUrls) {
+			stepUrls.forEach(url -> {
 				try {
 					parseUrl(url);
 				} catch (IOException e) {
 					System.err.printf("Failed to parse \"%s\" : %s\n", url,
 							e.getMessage());
 				}
-			}
+			});
 		}
 
 		stepUrls.clear();

--- a/src/org/graphstream/algorithm/measure/ClosenessCentrality.java
+++ b/src/org/graphstream/algorithm/measure/ClosenessCentrality.java
@@ -136,7 +136,7 @@ public class ClosenessCentrality extends AbstractCentrality {
 			node = graph.getNode(idx);
 			data[idx] = 0;
 
-			APSP.APSPInfo info = node.getAttribute(APSPInfo.ATTRIBUTE_NAME);
+			APSP.APSPInfo info = (APSPInfo) node.getAttribute(APSPInfo.ATTRIBUTE_NAME);
 
 			if (info == null)
 				System.err

--- a/src/org/graphstream/algorithm/measure/ConnectivityMeasure.java
+++ b/src/org/graphstream/algorithm/measure/ConnectivityMeasure.java
@@ -33,7 +33,6 @@ package org.graphstream.algorithm.measure;
 
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedList;
 
 import org.graphstream.algorithm.Algorithm;
@@ -72,9 +71,11 @@ public class ConnectivityMeasure {
 		/*
 		 * We start with the max degree.
 		 */
-		for (Node n : g.getEachNode())
-			current = Math.max(current, n.getDegree());
-
+		current = (g.nodes()
+			.max((x, y) -> Integer.compare(x.getDegree(), y.getDegree())) 
+			.get())
+			.getDegree();
+		
 		isCurrentConnected = isKVertexConnected(g, current);
 
 		do {
@@ -180,8 +181,8 @@ public class ConnectivityMeasure {
 		KIndexesArray karray = new KIndexesArray(k, g.getNodeCount());
 
 		if (k >= g.getNodeCount())
-			return g.getNodeSet().toArray(new Node[g.getNodeCount()]);
-
+			return g.nodes().toArray(Node[]::new);
+		
 		do {
 			toVisit.clear();
 			removed.clear();
@@ -196,19 +197,16 @@ public class ConnectivityMeasure {
 
 			while (toVisit.size() > 0) {
 				Node n = g.getNode(toVisit.poll());
-				Iterator<Node> it = n.getNeighborNodeIterator();
-				Integer index;
-
 				visited[n.getIndex()] = true;
-
-				while (it.hasNext()) {
-					Node o = it.next();
-					index = o.getIndex();
+				
+				n.neighborNodes().forEach(o -> {
+					Integer index = o.getIndex();
 
 					if (!visited[index] && !toVisit.contains(index)
 							&& !removed.contains(index))
 						toVisit.add(index);
-				}
+				});
+				
 			}
 
 			for (int i = 0; i < visited.length; i++)
@@ -245,8 +243,8 @@ public class ConnectivityMeasure {
 		Node nodeWithMinDegree = null;
 
 		if (k >= g.getEdgeCount())
-			return g.getEdgeSet().toArray(new Edge[g.getEdgeCount()]);
-
+			return g.edges().toArray(Edge[]::new);
+			
 		for (int i = 0; i < g.getNodeCount(); i++) {
 			Node n = g.getNode(i);
 
@@ -277,20 +275,17 @@ public class ConnectivityMeasure {
 
 			while (toVisit.size() > 0) {
 				Node n = g.getNode(toVisit.poll());
-				Iterator<Edge> it = n.iterator();
-				Integer index;
-
+				
 				visited[n.getIndex()] = true;
-
-				while (it.hasNext()) {
-					Edge e = it.next();
+				
+				n.edges().forEach(e -> {
 					Node o = e.getOpposite(n);
-					index = o.getIndex();
+					Integer index = o.getIndex();
 
 					if (!visited[index] && !toVisit.contains(index)
 							&& !removed.contains(e.getIndex()))
 						toVisit.add(index);
-				}
+				});
 			}
 
 			for (int i = 0; i < visited.length; i++)

--- a/src/org/graphstream/algorithm/networksimplex/DynamicOneToAllShortestPath.java
+++ b/src/org/graphstream/algorithm/networksimplex/DynamicOneToAllShortestPath.java
@@ -65,8 +65,8 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 	@Override
 	protected void cloneGraph() {
 		super.cloneGraph();
-		for (NSNode node : nodes.values())
-			node.supply = node.id.equals(sourceId) ? nodes.size() - 1 : -1;
+		
+		nodes.values().stream().forEach(node -> node.supply = node.id.equals(sourceId) ? nodes.size() - 1 : -1);			
 	}
 	
 	/**
@@ -92,15 +92,17 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 		Map<NSNode, NSNode> last = new HashMap<NSNode, NSNode>(4 * (nodes.size() + 1) / 3 + 1);
 		last.put(root, root);
 		root.thread = root;
-		for (NSNode node : nodes.values()) {
+		
+		nodes.values().forEach(node -> {
 			last.put(node, node);
 			node.artificialArc.status = ArcStatus.NONBASIC_LOWER;
 			node.artificialArc.flow = 0;
 			node.thread = node;
-		}
+		});
 		
 		// restore parent and thread
-		for (NSNode node : nodes.values()) {
+		
+		nodes.values().forEach(node -> {
 			Node gNode = graph.getNode(node.id);
 			Node gParent = dijkstra.getParent(gNode);
 			NSNode parent = gParent == null ? root : nodes.get(gParent.getId());
@@ -121,7 +123,8 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 			parent.thread = node;
 			for (NSNode x = parent; last.get(x) == parent; x = x.parent)
 				last.put(x, nodeLast);
-		}
+		});
+
 		last.clear();
 		dijkstra.clear();
 		
@@ -179,7 +182,7 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 
 	// Iterators
 
-	protected class NodeIterator<T extends Node> implements Iterator<T> {
+	protected class NodeIterator<T extends Node> implements Iterator<Node> {
 		protected NSNode nextNode;
 
 		protected NodeIterator(NSNode target) {
@@ -193,10 +196,10 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 			return nextNode != root;
 		}
 
-		public T next() {
+		public Node next() {
 			if (nextNode == root)
 				throw new NoSuchElementException();
-			T node = graph.getNode(nextNode.id);
+			Node node = graph.getNode(nextNode.id);
 			nextNode = nextNode.parent;
 			return node;
 		}
@@ -207,7 +210,7 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 		}
 	}
 
-	protected class EdgeIterator<T extends Edge> implements Iterator<T> {
+	protected class EdgeIterator<T extends Edge> implements Iterator<Edge> {
 		protected NSNode nextNode;
 
 		protected EdgeIterator(NSNode target) {
@@ -218,10 +221,10 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 			return nextNode.parent != root;
 		}
 
-		public T next() {
+		public Edge next() {
 			if (nextNode.parent == root)
 				throw new NoSuchElementException();
-			T edge = graph.getEdge(nextNode.arcToParent.getOriginalId());
+			Edge edge = graph.getEdge(nextNode.arcToParent.getOriginalId());
 			nextNode = nextNode.parent;
 			return edge;
 		}
@@ -257,7 +260,7 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 	 * @complexity Each call of {@link java.util.Iterator#next()} of this
 	 *             iterator takes O(1) time
 	 */
-	public <T extends Node> Iterator<T> getPathNodesIterator(Node target) {
+	public <T extends Node> Iterator<Node> getPathNodesIterator(Node target) {
 		return new NodeIterator<T>(nodes.get(target.getId()));
 	}
 
@@ -271,9 +274,9 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 	 *         source to the target
 	 * @see #getPathNodesIterator(Node)
 	 */
-	public <T extends Node> Iterable<T> getPathNodes(final Node target) {
-		return new Iterable<T>() {
-			public Iterator<T> iterator() {
+	public <T extends Node> Iterable<Node> getPathNodes(final Node target) {
+		return new Iterable<Node>() {
+			public Iterator<Node> iterator() {
 				return getPathNodesIterator(target);
 			}
 		};
@@ -296,8 +299,8 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 	 * @complexity Each call of {@link java.util.Iterator#next()} of this
 	 *             iterator takes O(1) time
 	 */
-	public <T extends Edge> Iterator<T> getPathEdgesIterator(Node target) {
-		return new EdgeIterator<T>(nodes.get(target.getId()));
+	public <T extends Edge> Iterator<Edge> getPathEdgesIterator(Node target) {
+		return new EdgeIterator<Edge>(nodes.get(target.getId()));
 	}
 
 	/**
@@ -310,9 +313,9 @@ public class DynamicOneToAllShortestPath extends NetworkSimplex {
 	 *         source to the target
 	 * @see #getPathEdgesIterator(Node)
 	 */
-	public <T extends Edge> Iterable<T> getPathEdges(final Node target) {
-		return new Iterable<T>() {
-			public Iterator<T> iterator() {
+	public <T extends Edge> Iterable<Edge> getPathEdges(final Node target) {
+		return new Iterable<Edge>() {
+			public Iterator<Edge> iterator() {
 				return getPathEdgesIterator(target);
 			}
 

--- a/src/org/graphstream/algorithm/networksimplex/NetworkSimplex.java
+++ b/src/org/graphstream/algorithm/networksimplex/NetworkSimplex.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.DoubleAccumulator;
 
 import org.graphstream.algorithm.DynamicAlgorithm;
 import org.graphstream.graph.Edge;
@@ -360,19 +361,22 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 			nodes.put(copy.id, copy);
 		}
 
-		int arcCount = graph.getEdgeCount();
-		for (Edge edge : graph.getEachEdge())
-			if (!edge.isDirected())
-				arcCount++;
-		arcs = new HashMap<String, NSArc>(4 * arcCount / 3 + 1);
-		for (Edge edge : graph.getEachEdge()) {
+		DoubleAccumulator arcCount = new DoubleAccumulator((x, y) -> x + y, graph.getEdgeCount()) ;
+		
+		graph.edges()
+			.filter(edge -> !edge.isDirected())
+			.forEach(edge -> arcCount.accumulate(1));
+
+		arcs = new HashMap<String, NSArc>(4 * (int)arcCount.get() / 3 + 1);
+		
+		graph.edges().forEach(edge -> {
 			NSArc copy = new NSArc(edge, true);
 			arcs.put(copy.id, copy);
 			if (!edge.isDirected()) {
 				copy = new NSArc(edge, false);
 				arcs.put(copy.id, copy);
 			}
-		}
+		});
 	}
 
 	/**
@@ -380,13 +384,15 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 	 */
 	protected void createInitialBFS() {
 		nonBasicArcs = new HashSet<NSArc>(4 * arcs.size() / 3 + 1);
-		for (NSArc arc : arcs.values()) {
+		
+		arcs.values().forEach(arc -> {
 			arc.flow = 0;
 			arc.status = ArcStatus.NONBASIC_LOWER;
 			nonBasicArcs.add(arc);
 			if (animationDelay > 0)
 				arc.setUIClass();
-		}
+		});
+		
 
 		root = new NSNode();
 		root.id = PREFIX + "ROOT";
@@ -398,8 +404,8 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 		root.artificialArc = null;
 
 		objectiveValue.set(0);
-		for (NSNode node : nodes.values())
-			node.createArtificialArc();
+
+		nodes.values().forEach(node -> node.createArtificialArc());
 		solutionStatus = SolutionStatus.UNDEFINED;
 	}
 
@@ -411,20 +417,20 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 	protected void selectEnteringArcFirstNegative() {
 		enteringArc = null;
 		BigMNumber reducedCost = work1;
-
-		for (NSArc arc : nonBasicArcs) {
+		
+		nonBasicArcs.forEach(arc -> {
 			arc.computeReducedCost(reducedCost);
 			if (reducedCost.isNegative()) {
 				enteringArc = arc;
 				return;
 			}
-		}
+		});
 		
 		// Skip the artificial arcs if the objective value is finite
 		if (!objectiveValue.isInfinite())
 			return;
-
-		for (NSNode node : nodes.values()) {
+		
+		nodes.values().forEach(node -> {
 			NSArc arc = node.artificialArc;
 			if (arc.status == ArcStatus.NONBASIC_LOWER) {
 				arc.computeReducedCost(reducedCost);
@@ -433,7 +439,7 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 					return;
 				}
 			}
-		}
+		});
 	}
 
 	/**
@@ -855,7 +861,7 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 	 *            A node
 	 * @return The edge to the parent of the node in the BFS tree
 	 */
-	public <T extends Edge> T getEdgeFromParent(Node node) {
+	public Edge getEdgeFromParent(Node node) {
 		NSArc arc = nodes.get(node.getId()).arcToParent;
 		if (arc.isArtificial())
 			return null;
@@ -871,7 +877,7 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 	 *            A node
 	 * @return The parent of a node in the BFS tree
 	 */
-	public <T extends Node> T getParent(Node node) {
+	public Node getParent(Node node) {
 		NSNode nsNode = nodes.get(node.getId());
 		if (nsNode == root)
 			return null;
@@ -985,14 +991,15 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 	 * </p>
 	 */
 	public void setUIClasses() {
-		for (Node node : graph)
-			nodes.get(node.getId()).artificialArc.setUIClass();
-		for (Edge edge : graph.getEachEdge()) {
+		
+		graph.nodes().forEach(node -> nodes.get(node.getId()).artificialArc.setUIClass());
+		
+		graph.edges().forEach(edge -> {
 			NSArc arc = arcs.get(edge.getId());
 			if (!edge.isDirected() && arc.status != ArcStatus.BASIC)
 				arc = arcs.get(PREFIX + "REVERSE_" + edge.getId());
 			arc.setUIClass();
-		}
+		});
 	}
 
 	// DynamicAlgorithm methods
@@ -1725,20 +1732,22 @@ public class NetworkSimplex extends SinkAdapter implements DynamicAlgorithm {
 		ps.println("=== Arcs ===");
 		ps.printf("%20s%10s%10s%10s%10s%20s%n", "id", "capacity", "cost",
 				"flow", "r. cost", "status");
-		for (NSArc a : arcs.values()) {
+		
+		arcs.values().forEach(a -> {
 			a.computeReducedCost(work1);
 			ps.printf("%20s%10s%10s%10s%10s%20s%n", a.id,
 					a.capacity == INFINITE_CAPACITY ? "Inf" : a.capacity,
 					a.cost, a.flow, work1, a.status);
-		}
-
-		for (NSNode node : nodes.values()) {
+		});
+		
+		nodes.values().forEach(node -> {
 			NSArc a = node.artificialArc;
 			a.computeReducedCost(work1);
 			ps.printf("%20s%10s%10s%10s%10s%20s%n", a.id,
 					a.capacity == INFINITE_CAPACITY ? "Inf" : a.capacity,
 					a.cost, a.flow, work1, a.status);
-		}
+		});
+
 
 		ps.println();
 		ps.printf("=== Objective value %s. Solution status %s ===%n%n",

--- a/src/org/graphstream/algorithm/randomWalk/RandomWalk.java
+++ b/src/org/graphstream/algorithm/randomWalk/RandomWalk.java
@@ -31,9 +31,10 @@
  */
 package org.graphstream.algorithm.randomWalk;
 
+import static org.graphstream.algorithm.Toolkit.randomNode;
+
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.Comparator;
 import java.util.Random;
 
@@ -42,8 +43,6 @@ import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Node;
 import org.graphstream.stream.SinkAdapter;
-
-import static org.graphstream.algorithm.Toolkit.*;
 
 /**
  * A random walk on a graph.
@@ -432,15 +431,16 @@ public class RandomWalk extends SinkAdapter implements DynamicAlgorithm {
 	 */
 	public void setPassesAttribute(String name) {
 		if (context.graph != null) {
-			for (Edge e : context.graph.getEachEdge()) {
+			
+			context.graph.edges().forEach(e -> {
 				e.setAttribute(name, e.getNumber(context.passesAttribute));
 				e.removeAttribute(context.passesAttribute);
-			}
-
-			for (Node n : context.graph) {
+			});
+			
+			context.graph.forEach(n -> {
 				n.setAttribute(name, n.getNumber(context.passesAttribute));
 				n.removeAttribute(context.passesAttribute);
-			}
+			});
 		}
 
 		context.passesAttribute = name;
@@ -549,9 +549,7 @@ public class RandomWalk extends SinkAdapter implements DynamicAlgorithm {
 		context.goCount = 0;
 		context.waitCount = 0;
 
-		for (Entity entity : entities) {
-			entity.step();
-		}
+		entities.forEach(entity -> entity.step());
 
 		if(evaporation<1)
 			evaporate();
@@ -561,12 +559,13 @@ public class RandomWalk extends SinkAdapter implements DynamicAlgorithm {
 	 * Apply evaporation on each edge.
 	 */
 	protected void evaporate() {
-		for(Edge edge: context.graph.getEachEdge()) {
+		context.graph.edges().forEach(edge -> {
 			edge.setAttribute(context.passesAttribute, edge.getNumber(context.passesAttribute)*evaporation);
-		}
-		for(Node node: context.graph) {
+		});
+		
+		context.graph.nodes().forEach(node -> {
 			node.setAttribute(context.passesAttribute, node.getNumber(context.passesAttribute)*evaporation);
-		}
+		});
 	}
 
 	/**
@@ -580,13 +579,9 @@ public class RandomWalk extends SinkAdapter implements DynamicAlgorithm {
 	}
 
 	protected void equipGraph() {
-		for (Edge e : context.graph.getEachEdge()) {
-			e.setAttribute(context.passesAttribute, 0.0);
-		}
+		context.graph.edges().forEach(e -> e.setAttribute(context.passesAttribute, 0.0));
 
-		for (Node n : context.graph) {
-			n.setAttribute(context.passesAttribute, 0.0);
-		}
+		context.graph.nodes().forEach(n -> n.setAttribute(context.passesAttribute, 0.0));
 	}
 
 	/**
@@ -598,12 +593,9 @@ public class RandomWalk extends SinkAdapter implements DynamicAlgorithm {
 	 */
 	public ArrayList<Edge> findTheMostUsedEdges() {
 		ArrayList<Edge> edges = new ArrayList<Edge>(context.graph.getEdgeCount());
-		Iterator<? extends Edge> i = context.graph.getEdgeIterator();
-
-		while (i.hasNext()) {
-			edges.add(i.next());
-		}
-
+		
+		context.graph.edges().forEach(e -> edges.add(e));
+		
 		Collections.sort(edges, new Comparator<Edge>() {
 			public int compare(Edge e1, Edge e2) {
 				int n1 = (int) e1.getNumber(context.passesAttribute);
@@ -625,11 +617,8 @@ public class RandomWalk extends SinkAdapter implements DynamicAlgorithm {
 	 */
 	public ArrayList<Node> findTheMostUsedNodes() {
 		ArrayList<Node> nodes = new ArrayList<Node>(context.graph.getNodeCount());
-		Iterator<? extends Node> i = context.graph.getNodeIterator();
-
-		while (i.hasNext()) {
-			nodes.add(i.next());
-		}
+				
+		context.graph.nodes().forEach(n -> nodes.add(n));
 
 		Collections.sort(nodes, new Comparator<Node>() {
 			public int compare(Node e1, Node e2) {

--- a/src/org/graphstream/algorithm/randomWalk/TabuEntity.java
+++ b/src/org/graphstream/algorithm/randomWalk/TabuEntity.java
@@ -34,7 +34,6 @@ package org.graphstream.algorithm.randomWalk;
 import static org.graphstream.algorithm.Toolkit.randomNode;
 
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 
 import org.graphstream.graph.Edge;
@@ -92,16 +91,11 @@ public class TabuEntity extends Entity {
 	 */
 	protected void tabuStep() {
 		int n = current.getOutDegree();
-		Iterator<? extends Edge> to = current.getLeavingEdgeIterator();
 		ArrayList<Edge> edges = new ArrayList<Edge>();
-
-		while (to.hasNext()) {
-			Edge e = to.next();
-
-			if (!tabu(e.getOpposite(current))) {
-				edges.add(e);
-			}
-		}
+		
+		current.leavingEdges()
+			.filter(e -> !tabu(e.getOpposite(current)))
+			.forEach(e -> edges.add(e));
 
 		n = edges.size();
 

--- a/src/org/graphstream/algorithm/util/DisjointSets.java
+++ b/src/org/graphstream/algorithm/util/DisjointSets.java
@@ -192,8 +192,8 @@ public class DisjointSets<E> {
 	 * no sets.
 	 */
 	public void clear() {
-		for (Node node : map.values())
-			node.parent = null;
+		map.values().forEach(node -> node.parent = null);
+		
 		map.clear();
 	}
 }

--- a/src/org/graphstream/algorithm/util/FibonacciHeap.java
+++ b/src/org/graphstream/algorithm/util/FibonacciHeap.java
@@ -327,8 +327,10 @@ public class FibonacciHeap<K extends Comparable<K>, V> {
 		} while (w != min);
 
 		min = null;
-		for (Node s : degList)
-			if (s != null) {
+		
+		degList.stream()
+			.filter(s -> s != null)
+			.forEach(s -> {
 				s.left = s.right = s;
 				if (min == null)
 					min = s;
@@ -337,7 +339,8 @@ public class FibonacciHeap<K extends Comparable<K>, V> {
 					if (s.key.compareTo(min.key) < 0)
 						min = s;
 				}
-			}
+			});
+			
 	}
 
 	/** Decreases the key of a given node

--- a/src/org/graphstream/ui/layout/HierarchicalLayout.java
+++ b/src/org/graphstream/ui/layout/HierarchicalLayout.java
@@ -42,7 +42,6 @@ import org.graphstream.algorithm.Prim;
 import org.graphstream.algorithm.SpanningTree;
 import org.graphstream.algorithm.generator.BarabasiAlbertGenerator;
 import org.graphstream.algorithm.util.FibonacciHeap;
-import org.graphstream.graph.Edge;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.Node;
 import org.graphstream.graph.implementations.AdjacencyListGraph;
@@ -176,21 +175,20 @@ public class HierarchicalLayout extends PipeBase implements Layout {
 				Node root = roots.poll();
 				int level = levels[root.getIndex()] + 1;
 				Box box = getChildrenBox(root);
-
-				for (Edge e : root.getEdgeSet()) {
-					if (e.getAttribute(tree.getFlagAttribute()).equals(
-							tree.getFlagOn())) {
+				
+				root.edges()
+					.filter(e -> e.getAttribute(tree.getFlagAttribute()).equals(tree.getFlagOn()))
+					.forEach(e -> {
 						Node op = e.getOpposite(root);
 
-						if (levels[op.getIndex()] < 0
-								|| level < levels[op.getIndex()]) {
+						if (levels[op.getIndex()] < 0 || level < levels[op.getIndex()]) {
 							levels[op.getIndex()] = level;
 							roots2.add(op);
 							op.setAttribute("parent", root);
 							setBox(box, op);
 						}
-					}
-				}
+					});
+				
 			}
 
 			roots.addAll(roots2);
@@ -256,12 +254,12 @@ public class HierarchicalLayout extends PipeBase implements Layout {
 	}
 
 	protected static Box getBox(Node node) {
-		Box box = node.getAttribute("box");
+		Box box = (Box) node.getAttribute("box");
 		return box;
 	}
 
 	protected static Box getChildrenBox(Node node) {
-		Box box = node.getAttribute("children");
+		Box box = (Box) node.getAttribute("children");
 		return box;
 	}
 
@@ -334,14 +332,15 @@ public class HierarchicalLayout extends PipeBase implements Layout {
 	}
 
 	protected void publishPositions() {
-		for (Node n : internalGraph) {
-			if (n.hasAttribute("changed")) {
+		
+		internalGraph.nodes()
+			.filter(n -> n.hasAttribute("changed"))
+			.forEach(n -> {
 				n.removeAttribute("changed");
 
 				sendNodeAttributeChanged(sourceId, n.getId(), "xyz", null,
 						new double[] { n.getNumber("x"), n.getNumber("y"), 0 });
-			}
-		}
+			});
 	}
 
 	/*


### PR DESCRIPTION
I would like us to discuss about the last commit of this PR.
Some algorithm dispose of internal iterator. Hard-coded an implementation of Streams is possible, but tedious. Usually we use a Factory.

 For the transition into Stream, I am proposing solution for this iterators :

- Conservation of iterator classes
- Removal generics
- SpanningTree interface and abstract class return an Iterable and a Stream
- Methods "get ... Iterator" changes to "get ... Stream" and uses a Spliterators
