### PR TITLE
refactoring topological sort

### DIFF
--- a/src-test/org/graphstream/algorithm/test/TestTopologicalSortDFS.java
+++ b/src-test/org/graphstream/algorithm/test/TestTopologicalSortDFS.java
@@ -1,0 +1,78 @@
+package org.graphstream.algorithm.test;
+
+import org.graphstream.algorithm.TopologicalSortDFS;
+import org.graphstream.graph.Graph;
+import org.graphstream.graph.implementations.SingleGraph;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TestTopologicalSortDFS {
+
+    Graph graph;
+
+    @Before
+    public void prepare() {
+        graph = new SingleGraph("Graph");
+        graph.addNode("0");
+        graph.addNode("1");
+        graph.addNode("2");
+        graph.addNode("3");
+        graph.addNode("4");
+        graph.addNode("5");
+        graph.addEdge("5-2", "5", "2", true);
+        graph.addEdge("5-0", "5", "0", true);
+        graph.addEdge("4-0", "4", "0", true);
+        graph.addEdge("4-1", "4", "1", true);
+        graph.addEdge("3-1", "3", "1", true);
+        graph.addEdge("2-3", "2", "3", true);
+    }
+
+    @Test
+    public void testTopologicalSortSmallGraph() {
+        List<String> allPossibleTopologicalSort = new ArrayList<>();
+
+        //all possible topological orderings
+        allPossibleTopologicalSort.add("[4, 5, 0, 2, 3, 1]");
+        allPossibleTopologicalSort.add("[4, 5, 2, 0, 3, 1]");
+        allPossibleTopologicalSort.add("[4, 5, 2. 3. 0, 1]");
+        allPossibleTopologicalSort.add("[4, 5, 2, 3, 1, 0]");
+
+        allPossibleTopologicalSort.add("[5, 2, 3, 4, 0, 1]");
+        allPossibleTopologicalSort.add("[5, 2, 3, 4, 1, 0]");
+        allPossibleTopologicalSort.add("[5, 2, 4, 0, 3, 1]");
+        allPossibleTopologicalSort.add("[5, 2, 4, 3, 0, l]");
+        allPossibleTopologicalSort.add("[5, 2, 4, 3, 1, 0]");
+
+        allPossibleTopologicalSort.add("[5, 4, 0, 2, 3, 1]");
+        allPossibleTopologicalSort.add("[5, 4, 2, 8, 3, l]");
+        allPossibleTopologicalSort.add("[5, 4, 2, 3, 0, 1]");
+        allPossibleTopologicalSort.add("[5, 4, 2, 3, 1, 0]");
+        TopologicalSortDFS sort = new TopologicalSortDFS();
+        sort.init(graph);
+        sort.compute();
+
+        //check if algorithm gets one of the possible ordering
+        Assert.assertTrue(allPossibleTopologicalSort.contains(Arrays.toString(sort.getSortedNodes().toArray())));
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGraphWithCyclesShouldThrowException() {
+        graph.addEdge("3-5", "3", "5", true);
+        TopologicalSortDFS sort = new TopologicalSortDFS();
+        sort.init(graph);
+        sort.compute();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testGraphWithNonDirectedEdgeShouldThrowException() {
+        graph.addEdge("3-5", "3", "5");
+        TopologicalSortDFS sort = new TopologicalSortDFS();
+        sort.init(graph);
+        sort.compute();
+    }
+}

--- a/src-test/org/graphstream/algorithm/test/TestTopologicalSortKahn.java
+++ b/src-test/org/graphstream/algorithm/test/TestTopologicalSortKahn.java
@@ -1,6 +1,6 @@
 package org.graphstream.algorithm.test;
 
-import org.graphstream.algorithm.TopologicalSort;
+import org.graphstream.algorithm.TopologicalSortKahn;
 import org.graphstream.graph.Graph;
 import org.graphstream.graph.implementations.SingleGraph;
 import org.junit.Assert;
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public class TestTopologicalSort {
+public class TestTopologicalSortKahn {
 
     Graph graph;
 
@@ -52,7 +52,7 @@ public class TestTopologicalSort {
         allPossibleTopologicalSort.add("[5, 4, 2, 8, 3, l]");
         allPossibleTopologicalSort.add("[5, 4, 2, 3, 0, 1]");
         allPossibleTopologicalSort.add("[5, 4, 2, 3, 1, 0]");
-        TopologicalSort sort = new TopologicalSort();
+        TopologicalSortKahn sort = new TopologicalSortKahn();
         sort.init(graph);
         sort.compute();
 
@@ -63,7 +63,7 @@ public class TestTopologicalSort {
     @Test(expected = IllegalStateException.class)
     public void testGraphWithCyclesShouldThrowException() {
         graph.addEdge("3-5", "3", "5", true);
-        TopologicalSort sort = new TopologicalSort();
+        TopologicalSortKahn sort = new TopologicalSortKahn();
         sort.init(graph);
         sort.compute();
     }
@@ -71,7 +71,7 @@ public class TestTopologicalSort {
     @Test(expected = IllegalStateException.class)
     public void testGraphWithNonDirectedEdgeShouldThrowException() {
         graph.addEdge("3-5", "3", "5");
-        TopologicalSort sort = new TopologicalSort();
+        TopologicalSortKahn sort = new TopologicalSortKahn();
         sort.init(graph);
         sort.compute();
     }

--- a/src/org/graphstream/algorithm/TopologicalSortDFS.java
+++ b/src/org/graphstream/algorithm/TopologicalSortDFS.java
@@ -1,0 +1,87 @@
+package org.graphstream.algorithm;
+
+import org.graphstream.graph.Graph;
+import org.graphstream.graph.Node;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * Implementation of depth first search algorithm for a topological sorting of a directed acyclic graph (DAG).
+ * Every DAG has at least one topological ordering and this is a algorithm known for constructing a
+ * topological ordering in linear time.
+ *
+ * @reference Tarjan, Robert E. (1976), "Edge-disjoint spanning trees and depth-first search", Acta Informatica, 6 (2): 171–185
+ * @complexity O(VxE) time, where V and E are the number of vertices and edges
+ * respectively.
+ */
+public class TopologicalSortDFS implements Algorithm{
+
+    /**
+     * graph to calculate a topological ordering
+     */
+    private Graph graph;
+
+    /**
+     * collection containing sorted nodes after calculation
+     */
+    private List<Node> sortedNodes;
+
+    /**
+     * collection to mark visited nodes
+     */
+    private HashSet<Node> markedNodeList = new HashSet<>();
+
+    /**
+     * collection to mark temporary visited node needed to throw exception
+     */
+    private HashSet<Node> tempMarkedNodeList = new HashSet<>();
+
+    @Override
+    public void init(Graph theGraph) {
+        graph = theGraph;
+        sortedNodes = new ArrayList<>();
+    }
+
+    @Override
+    public void compute() {
+        while (markedNodeList.size() != graph.nodes().count()){
+            graph.nodes().forEach(this::visit);
+        }
+        Collections.reverse(sortedNodes);
+    }
+
+    /**
+     * Recursive function to compute topo sort
+     * @param theNode
+     */
+    private void visit(Node theNode) {
+        if(markedNodeList.contains(theNode)){
+            return;
+        }
+        if(tempMarkedNodeList.contains(theNode)){
+            throwException();
+        }
+        tempMarkedNodeList.add(theNode);
+        theNode.leavingEdges().forEach(anEdge -> visit(anEdge.getTargetNode()));
+        markedNodeList.add(theNode);
+        sortedNodes.add(theNode);
+    }
+
+    /**
+     * throws exception if given graph is no directed acyclic graph (DAG)
+     */
+    private void throwException() {
+        throw new IllegalStateException("graph is no DAG");
+    }
+
+    /**
+     * gets sorted list of the given graph
+     * @return topological sorted list of nodes
+     */
+    public List<Node> getSortedNodes() {
+        return sortedNodes;
+    }
+}

--- a/src/org/graphstream/algorithm/TopologicalSortDFS.java
+++ b/src/org/graphstream/algorithm/TopologicalSortDFS.java
@@ -32,17 +32,19 @@ public class TopologicalSortDFS implements Algorithm{
     /**
      * collection to mark visited nodes
      */
-    private HashSet<Node> markedNodeList = new HashSet<>();
+    private HashSet<Node> markedNodeList;
 
     /**
      * collection to mark temporary visited node needed to throw exception
      */
-    private HashSet<Node> tempMarkedNodeList = new HashSet<>();
+    private HashSet<Node> tempMarkedNodeList;
 
     @Override
     public void init(Graph theGraph) {
         graph = theGraph;
         sortedNodes = new ArrayList<>();
+        markedNodeList = new HashSet<>();
+        tempMarkedNodeList = new HashSet<>();
     }
 
     @Override


### PR DESCRIPTION
Dear graphstream community
I was not very pleased to see that algorithms are changed completely by just introducing streams into every loop and leave out the rest just for streams sake. And please at least include the original contributors in your pull request. So here is a refactored version of the topological sorting both for depth-first search (DFS) and for Kahn. This is important because kahn needs to do a copy of the graph O(N+E) and needs to find source nodes O(n). In comparison DFS does not need to do that and is therefore a lot faster. I will leave it up to the community to decide if we need both algorithms but if you pick one do not pick Kahn.
Can someone please add reviewers especially Brahimi, hchokshi and MayanHut.

Thank you
